### PR TITLE
Remove submodule in spec/fixtures/augeas 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "augeas"]
-	path = spec/fixtures/augeas
-	url = git://github.com/hercules-team/augeas.git


### PR DESCRIPTION

Pull Request (PR) description

github.com permanently disabled unencrypted git on 15/3/22: https://github.blog/2021-09-01-improving-git-protocol-security-github/, which means that updating this repository's submodules currently fails.

This PR changes the submodule URL in question to an equivalent HTTPS URL that works.

cf. https://github.com/voxpupuli/puppet-augeasproviders_core/pull/38

This Pull Request (PR) fixes the following issues

n/a

