### PR TITLE
Fix crash when existing commented entry with no value

### DIFF
--- a/lib/puppet/provider/shellvar/augeas.rb
+++ b/lib/puppet/provider/shellvar/augeas.rb
@@ -195,8 +195,11 @@ Puppet::Type.type(:shellvar).provide(:augeas, parent: Puppet::Type.type(:augeasp
       unless commented.empty?
         commented_values = if aug.get(commented.first).include?('=')
                              value = aug.get(commented.first).split('=')[1]
-                             return nil if value.nil?
-                             unquoteit(value).split(' ')
+                             if value.nil? || value.empty?
+                               []
+                             else
+                               unquoteit(value).split(' ')
+                             end
                            else
                              unquoteit(aug.get(commented.first)).split(' ')
                            end

--- a/spec/fixtures/unit/puppet/provider/shellvar/augeas/commented_no_value
+++ b/spec/fixtures/unit/puppet/provider/shellvar/augeas/commented_no_value
@@ -1,0 +1,3 @@
+# CRYPTO_POLICY=
+# Some other comment
+EXISTING_VAR=value

--- a/spec/unit/puppet/provider/shellvar/augeas_spec.rb
+++ b/spec/unit/puppet/provider/shellvar/augeas_spec.rb
@@ -774,4 +774,41 @@ baz fooz\"" }
       ')
     end
   end
+
+  context 'with commented file containing variable with no value' do
+    let(:tmptarget) { aug_fixture('commented_no_value') }
+    let(:target) { tmptarget.path }
+
+    it 'creates new entry when commented variable has no value' do
+      apply!(Puppet::Type.type(:shellvar).new(
+               name: 'CRYPTO_POLICY',
+               value: 'DEFAULT',
+               target: target,
+               provider: 'augeas',
+      ))
+
+      augparse(target, 'Shellvars.lns', '
+        { "#comment" = "CRYPTO_POLICY=" }
+        { "CRYPTO_POLICY" = "DEFAULT" }
+        { "#comment" = "Some other comment" }
+        { "EXISTING_VAR" = "value" }
+      ')
+    end
+
+    it 'creates new entry with uncomment when commented variable has no value' do
+      apply!(Puppet::Type.type(:shellvar).new(
+               name: 'CRYPTO_POLICY',
+               value: 'DEFAULT',
+               uncomment: true,
+               target: target,
+               provider: 'augeas',
+      ))
+
+      augparse(target, 'Shellvars.lns', '
+        { "CRYPTO_POLICY" = "DEFAULT" }
+        { "#comment" = "Some other comment" }
+        { "EXISTING_VAR" = "value" }
+      ')
+    end
+  end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

Do not crash when trying to create a new variable that has a commented entry with no value.

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-augeasproviders_shellvar/issues/39
